### PR TITLE
t/3: Implemented a keystroke to display the toolbar in a collapsed selection

### DIFF
--- a/src/balloontoolbareditorui.js
+++ b/src/balloontoolbareditorui.js
@@ -70,10 +70,10 @@ export default class BalloonToolbarEditorUI {
 			originFocusTracker: this.focusTracker,
 			originKeystrokeHandler: editor.keystrokes,
 			toolbar: contextualToolbar.toolbarView,
-			beforeFocus: () => {
+			beforeFocus() {
 				return contextualToolbar.show();
 			},
-			afterBlur: () => {
+			afterBlur() {
 				contextualToolbar.hide();
 			}
 		} );

--- a/src/balloontoolbareditorui.js
+++ b/src/balloontoolbareditorui.js
@@ -70,7 +70,13 @@ export default class BalloonToolbarEditorUI {
 				origin: editor.editing.view,
 				originFocusTracker: this.focusTracker,
 				originKeystrokeHandler: editor.keystrokes,
-				toolbar: contextualToolbar.toolbarView
+				toolbar: contextualToolbar.toolbarView,
+				beforeFocus: () => {
+					return contextualToolbar.show();
+				},
+				afterBlur: () => {
+					contextualToolbar.hide();
+				}
 			} );
 		} );
 	}

--- a/src/balloontoolbareditorui.js
+++ b/src/balloontoolbareditorui.js
@@ -71,7 +71,7 @@ export default class BalloonToolbarEditorUI {
 			originKeystrokeHandler: editor.keystrokes,
 			toolbar: contextualToolbar.toolbarView,
 			beforeFocus() {
-				return contextualToolbar.show();
+				contextualToolbar.show();
 			},
 			afterBlur() {
 				contextualToolbar.hide();

--- a/tests/balloontoolbareditorui.js
+++ b/tests/balloontoolbareditorui.js
@@ -11,14 +11,9 @@ import BalloonToolbarEditorUI from '../src/balloontoolbareditorui';
 import BalloonToolbarEditorUIView from '../src/balloontoolbareditoruiview';
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
 import ContextualToolbar from '@ckeditor/ckeditor5-ui/src/toolbar/contextual/contextualtoolbar';
-
 import FocusTracker from '@ckeditor/ckeditor5-utils/src/focustracker';
-
 import { keyCodes } from '@ckeditor/ckeditor5-utils/src/keyboard';
-import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 import utils from '@ckeditor/ckeditor5-utils/tests/_utils/utils';
-
-testUtils.createSinonSandbox();
 
 describe( 'BalloonToolbarEditorUI', () => {
 	let editorElement, editor, editable, view, ui;
@@ -106,10 +101,15 @@ describe( 'BalloonToolbarEditorUI', () => {
 
 		it( 'initializes keyboard navigation between view#toolbar and view#editable', () => {
 			const toolbar = editor.plugins.get( 'ContextualToolbar' );
-			const spy = testUtils.sinon.spy( toolbar.toolbarView, 'focus' );
+			const toolbarFocusSpy = sinon.stub( toolbar.toolbarView, 'focus', () => {} );
+			const toolbarShowSpy = sinon.stub( toolbar, 'show', () => {} );
+			const toolbarHideSpy = sinon.stub( toolbar, 'hide', () => {} );
+			const editingFocusSpy = sinon.stub( editor.editing.view, 'focus', () => {} );
 
 			ui.init();
 			ui.focusTracker.isFocused = true;
+
+			// #show and #hide are mocked so mocking the focus as well.
 			toolbar.toolbarView.focusTracker.isFocused = false;
 
 			editor.keystrokes.press( {
@@ -119,7 +119,20 @@ describe( 'BalloonToolbarEditorUI', () => {
 				stopPropagation: sinon.spy()
 			} );
 
-			sinon.assert.calledOnce( spy );
+			sinon.assert.callOrder( toolbarShowSpy, toolbarFocusSpy );
+			sinon.assert.notCalled( toolbarHideSpy );
+			sinon.assert.notCalled( editingFocusSpy );
+
+			// #show and #hide are mocked so mocking the focus as well.
+			toolbar.toolbarView.focusTracker.isFocused = true;
+
+			toolbar.toolbarView.keystrokes.press( {
+				keyCode: keyCodes.esc,
+				preventDefault: sinon.spy(),
+				stopPropagation: sinon.spy()
+			} );
+
+			sinon.assert.callOrder( editingFocusSpy, toolbarHideSpy );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Implemented a keystroke to display the toolbar in a collapsed selection. Closes ckeditor/ckeditor5#2344.

---

Requires https://github.com/ckeditor/ckeditor5-ui/pull/270.