### PR TITLE
Allow to pass initial data to the editor constructor

### DIFF
--- a/src/ballooneditor.js
+++ b/src/ballooneditor.js
@@ -64,16 +64,6 @@ export default class BalloonEditor extends Editor {
 	constructor( sourceElementOrData, config ) {
 		super( config );
 
-		/**
-		 * The element on which the editor has been initialized.
-		 * If editor was initialized with data instead of HTMLElement this property will keep a reference to newly
-		 * created element that need to be added manually to the DOM. For more information see
-		 * {@link module:editor-balloon/ballooneditor~BalloonEditor.create `BalloonEditor.create()`}.
-		 *
-		 * @readonly
-		 * @member {HTMLElement} #element
-		 */
-
 		if ( isElement( sourceElementOrData ) ) {
 			this.sourceElement = sourceElementOrData;
 		}

--- a/src/ballooneditor.js
+++ b/src/ballooneditor.js
@@ -195,9 +195,11 @@ export default class BalloonEditor extends Editor {
 						editor.fire( 'uiReady' );
 					} )
 					.then( () => {
-						const data = isElement( sourceElementOrData ) ? getDataFromElement( sourceElementOrData ) : sourceElementOrData;
+						const initialData = isElement( sourceElementOrData ) ?
+							getDataFromElement( sourceElementOrData ) :
+							sourceElementOrData;
 
-						return editor.data.init( data );
+						return editor.data.init( initialData );
 					} )
 					.then( () => {
 						editor.fire( 'dataReady' );

--- a/src/ballooneditor.js
+++ b/src/ballooneditor.js
@@ -137,6 +137,27 @@ export default class BalloonEditor extends Editor {
 	 *
 	 * Creating instance when using initial data instead of DOM element:
 	 *
+	 *		import BalloonEditor from '@ckeditor/ckeditor5-editor-balloon/src/ballooneditor';
+	 *		import Essentials from '@ckeditor/ckeditor5-essentials/src/essentials';
+	 *		import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
+	 *		import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic';
+	 *		import ...
+	 *
+	 *		BalloonEditor
+	 *			.create( '<p>Hello world!</p>', {
+	 *				plugins: [ Essentials, Bold, Italic, ... ],
+	 *				toolbar: [ 'bold', 'italic', ... ]
+	 *			} )
+	 *			.then( editor => {
+	 *				console.log( 'Editor was initialized', editor );
+	 *
+	 *				// Initial data was provided so `editor.element` needs to be added manually to the DOM.
+	 *				document.body.appendChild( editor.element );
+	 *			} )
+	 *			.catch( err => {
+	 *				console.error( err.stack );
+	 *			} );
+	 *
 	 * @param {HTMLElement|String} elementOrData The DOM element that will be the source for the created editor
 	 * (on which the editor will be initialized) or initial data for the editor. If data is provided, `editor.element`
 	 * will be created automatically and need to be added manually to the DOM.

--- a/src/ballooneditor.js
+++ b/src/ballooneditor.js
@@ -65,6 +65,16 @@ export default class BalloonEditor extends Editor {
 	constructor( elementOrData, config ) {
 		super( config );
 
+		/**
+		 * The element on which the editor has been initialized.
+		 * If editor was initialized with data instead of HTMLElement this property will keep a reference to newly
+		 * created element that need to be added manually to the DOM. For more information see
+		 * {@link module:editor-balloon/ballooneditor~BalloonEditor.create `BalloonEditor.create()`}.
+		 *
+		 * @readonly
+		 * @member {HTMLElement} #element
+		 */
+
 		if ( isElement( elementOrData ) ) {
 			this.element = elementOrData;
 		} else {
@@ -160,7 +170,8 @@ export default class BalloonEditor extends Editor {
 	 *
 	 * @param {HTMLElement|String} elementOrData The DOM element that will be the source for the created editor
 	 * (on which the editor will be initialized) or initial data for the editor. If data is provided, `editor.element`
-	 * will be created automatically and need to be added manually to the DOM.
+	 * will be created automatically and need to be added manually to the DOM. The element is initialized as a `div`
+	 * element crated in current document's context.
 	 * @param {module:core/editor/editorconfig~EditorConfig} config The editor configuration.
 	 * @returns {Promise} A promise resolved once the editor is ready.
 	 * The promise returns the created {@link module:editor-balloon/ballooneditor~BalloonEditor} instance.

--- a/src/ballooneditor.js
+++ b/src/ballooneditor.js
@@ -56,8 +56,7 @@ export default class BalloonEditor extends Editor {
 	 *
 	 * @protected
 	 * @param {HTMLElement|String} sourceElementOrData The DOM element that will be the source for the created editor
-	 * (on which the editor will be initialized) or initial data for the editor. If data is provided, `editor.element`
-	 * will be created automatically and need to be added manually to the DOM. For more information see
+	 * (on which the editor will be initialized) or initial data for the editor. For more information see
 	 * {@link module:editor-balloon/ballooneditor~BalloonEditor.create `BalloonEditor.create()`}.
 	 * @param {module:core/editor/editorconfig~EditorConfig} config The editor configuration.
 	 */
@@ -143,7 +142,7 @@ export default class BalloonEditor extends Editor {
 	 *				console.error( err.stack );
 	 *			} );
 	 *
-	 * Creating instance when using initial data instead of DOM element:
+	 * Creating instance when using initial data instead of a DOM element:
 	 *
 	 *		import BalloonEditor from '@ckeditor/ckeditor5-editor-balloon/src/ballooneditor';
 	 *		import Essentials from '@ckeditor/ckeditor5-essentials/src/essentials';
@@ -167,9 +166,14 @@ export default class BalloonEditor extends Editor {
 	 *			} );
 	 *
 	 * @param {HTMLElement|String} sourceElementOrData The DOM element that will be the source for the created editor
-	 * (on which the editor will be initialized) or initial data for the editor. If data is provided, `editor.element`
-	 * will be created automatically and need to be added manually to the DOM. The element is initialized as a `div`
-	 * element crated in current document's context.
+	 * (on which the editor will be initialized) or initial data for the editor.
+	 *
+	 * If a source element is passed, then its contents will be automatically
+	 * {@link module:editor-classic/ballooneditor~BalloonEditor#setData loaded} to the editor on startup and the element
+	 * itself will be used as the editor's editable element.
+	 *
+	 * If data is provided, then `editor.element` will be created automatically and needs to be added
+	 * to the DOM manually.
 	 * @param {module:core/editor/editorconfig~EditorConfig} config The editor configuration.
 	 * @returns {Promise} A promise resolved once the editor is ready.
 	 * The promise returns the created {@link module:editor-balloon/ballooneditor~BalloonEditor} instance.

--- a/src/ballooneditor.js
+++ b/src/ballooneditor.js
@@ -19,7 +19,6 @@ import ElementApiMixin from '@ckeditor/ckeditor5-core/src/editor/utils/elementap
 import attachToForm from '@ckeditor/ckeditor5-core/src/editor/utils/attachtoform';
 import mix from '@ckeditor/ckeditor5-utils/src/mix';
 import isElement from '@ckeditor/ckeditor5-utils/src/lib/lodash/isElement';
-import global from '@ckeditor/ckeditor5-utils/src/dom/global';
 
 /**
  * The {@glink builds/guides/overview#balloon-editor balloon editor} implementation (Medium-like editor).
@@ -77,8 +76,6 @@ export default class BalloonEditor extends Editor {
 
 		if ( isElement( sourceElementOrData ) ) {
 			this.sourceElement = sourceElementOrData;
-		} else {
-			this.sourceElement = global.document.createElement( 'div' );
 		}
 
 		this.config.get( 'plugins' ).push( BalloonToolbar );
@@ -94,9 +91,7 @@ export default class BalloonEditor extends Editor {
 	}
 
 	/**
-	 * An HTML element that represents the whole editor. See the {@link module:core/editor/editorwithui~EditorWithUI} interface.
-	 *
-	 * @returns {HTMLElement|null}
+	 * @inheritDoc
 	 */
 	get element() {
 		return this.ui.view.editable.element;
@@ -117,7 +112,11 @@ export default class BalloonEditor extends Editor {
 		this.ui.destroy();
 
 		return super.destroy()
-			.then( () => setDataInElement( this.sourceElement, data ) );
+			.then( () => {
+				if ( this.sourceElement ) {
+					setDataInElement( this.sourceElement, data );
+				}
+			} );
 	}
 
 	/**
@@ -195,7 +194,11 @@ export default class BalloonEditor extends Editor {
 						editor.ui.init();
 						editor.fire( 'uiReady' );
 					} )
-					.then( () => editor.data.init( isElement( sourceElementOrData ) ? getDataFromElement( sourceElementOrData ) : sourceElementOrData ) )
+					.then( () => {
+						const data = isElement( sourceElementOrData ) ? getDataFromElement( sourceElementOrData ) : sourceElementOrData;
+
+						return editor.data.init( data );
+					} )
 					.then( () => {
 						editor.fire( 'dataReady' );
 						editor.fire( 'ready' );

--- a/src/ballooneditor.js
+++ b/src/ballooneditor.js
@@ -56,13 +56,13 @@ export default class BalloonEditor extends Editor {
 	 * {@link module:editor-balloon/ballooneditor~BalloonEditor.create `BalloonEditor.create()`} method instead.
 	 *
 	 * @protected
-	 * @param {HTMLElement|String} elementOrData The DOM element that will be the source for the created editor
+	 * @param {HTMLElement|String} sourceElementOrData The DOM element that will be the source for the created editor
 	 * (on which the editor will be initialized) or initial data for the editor. If data is provided, `editor.element`
 	 * will be created automatically and need to be added manually to the DOM. For more information see
 	 * {@link module:editor-balloon/ballooneditor~BalloonEditor.create `BalloonEditor.create()`}.
 	 * @param {module:core/editor/editorconfig~EditorConfig} config The editor configuration.
 	 */
-	constructor( elementOrData, config ) {
+	constructor( sourceElementOrData, config ) {
 		super( config );
 
 		/**
@@ -75,10 +75,10 @@ export default class BalloonEditor extends Editor {
 		 * @member {HTMLElement} #element
 		 */
 
-		if ( isElement( elementOrData ) ) {
-			this.element = elementOrData;
+		if ( isElement( sourceElementOrData ) ) {
+			this.sourceElement = sourceElementOrData;
 		} else {
-			this.element = global.document.createElement( 'div' );
+			this.sourceElement = global.document.createElement( 'div' );
 		}
 
 		this.config.get( 'plugins' ).push( BalloonToolbar );
@@ -88,9 +88,18 @@ export default class BalloonEditor extends Editor {
 
 		this.model.document.createRoot();
 
-		this.ui = new BalloonEditorUI( this, new BalloonEditorUIView( this.locale, this.element ) );
+		this.ui = new BalloonEditorUI( this, new BalloonEditorUIView( this.locale, this.sourceElement ) );
 
 		attachToForm( this );
+	}
+
+	/**
+	 * An HTML element that represents the whole editor. See the {@link module:core/editor/editorwithui~EditorWithUI} interface.
+	 *
+	 * @returns {HTMLElement|null}
+	 */
+	get element() {
+		return this.ui.view.editable.element;
 	}
 
 	/**
@@ -108,7 +117,7 @@ export default class BalloonEditor extends Editor {
 		this.ui.destroy();
 
 		return super.destroy()
-			.then( () => setDataInElement( this.element, data ) );
+			.then( () => setDataInElement( this.sourceElement, data ) );
 	}
 
 	/**
@@ -168,7 +177,7 @@ export default class BalloonEditor extends Editor {
 	 *				console.error( err.stack );
 	 *			} );
 	 *
-	 * @param {HTMLElement|String} elementOrData The DOM element that will be the source for the created editor
+	 * @param {HTMLElement|String} sourceElementOrData The DOM element that will be the source for the created editor
 	 * (on which the editor will be initialized) or initial data for the editor. If data is provided, `editor.element`
 	 * will be created automatically and need to be added manually to the DOM. The element is initialized as a `div`
 	 * element crated in current document's context.
@@ -176,9 +185,9 @@ export default class BalloonEditor extends Editor {
 	 * @returns {Promise} A promise resolved once the editor is ready.
 	 * The promise returns the created {@link module:editor-balloon/ballooneditor~BalloonEditor} instance.
 	 */
-	static create( elementOrData, config ) {
+	static create( sourceElementOrData, config ) {
 		return new Promise( resolve => {
-			const editor = new this( elementOrData, config );
+			const editor = new this( sourceElementOrData, config );
 
 			resolve(
 				editor.initPlugins()
@@ -186,7 +195,7 @@ export default class BalloonEditor extends Editor {
 						editor.ui.init();
 						editor.fire( 'uiReady' );
 					} )
-					.then( () => editor.data.init( isElement( elementOrData ) ? getDataFromElement( elementOrData ) : elementOrData ) )
+					.then( () => editor.data.init( isElement( sourceElementOrData ) ? getDataFromElement( sourceElementOrData ) : sourceElementOrData ) )
 					.then( () => {
 						editor.fire( 'dataReady' );
 						editor.fire( 'ready' );

--- a/src/ballooneditoruiview.js
+++ b/src/ballooneditoruiview.js
@@ -20,6 +20,9 @@ export default class BalloonEditorUIView extends EditorUIView {
 	 * Creates an instance of the balloon editor UI view.
 	 *
 	 * @param {module:utils/locale~Locale} locale The {@link module:core/editor/editor~Editor#locale} instance.
+	 * @param {HTMLElement} [editableElement] The editable element. If not specified, the
+	 * {@link module:ui/editableui/editableuiview~EditableUIView}
+	 * will create it. Otherwise, the existing element will be used.
 	 */
 	constructor( locale, editableElement ) {
 		super( locale );

--- a/tests/ballooneditor.js
+++ b/tests/ballooneditor.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-/* globals document, Event */
+/* globals document, Event, HTMLElement */
 
 import BalloonEditorUI from '../src/ballooneditorui';
 import BalloonEditorUIView from '../src/ballooneditoruiview';
@@ -100,6 +100,24 @@ describe( 'BalloonEditor', () => {
 				return editor.destroy().then( () => {
 					form.remove();
 				} );
+			} );
+		} );
+
+		it( 'allows to pass data to the constructor', () => {
+			return BalloonEditor.create( '<p>Hello world!</p>', {
+				plugins: [ Paragraph ]
+			} ).then( editor => {
+				expect( editor.getData() ).to.equal( '<p>Hello world!</p>' );
+			} );
+		} );
+
+		it( 'editor.element should contain created div element', () => {
+			return BalloonEditor.create( '<p>Hello world!</p>', {
+				plugins: [ Paragraph ]
+			} ).then( editor => {
+				expect( editor.element ).to.be.instanceOf( HTMLElement );
+				expect( editor.element.tagName ).to.equal( 'DIV' );
+				expect( editor.editing.view.getDomRoot() ).to.equal( editor.element );
 			} );
 		} );
 	} );

--- a/tests/ballooneditor.js
+++ b/tests/ballooneditor.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-/* globals document, Event, HTMLElement */
+/* globals document, Event */
 
 import BalloonEditorUI from '../src/ballooneditorui';
 import BalloonEditorUIView from '../src/ballooneditoruiview';
@@ -111,16 +111,19 @@ describe( 'BalloonEditor', () => {
 			} );
 		} );
 
-		it( 'editor.sourceElement should contain created div element', () => {
-			return BalloonEditor.create( '<p>Hello world!</p>', {
-				plugins: [ Paragraph ]
-			} ).then( editor => {
-				expect( editor.sourceElement ).to.be.instanceOf( HTMLElement );
-				expect( editor.sourceElement.tagName ).to.equal( 'DIV' );
-			} );
+		it( 'should have undefined the #sourceElement if editor was initialized with data', () => {
+			return BalloonEditor
+				.create( '<p>Foo.</p>', {
+					plugins: [ Paragraph, Bold ]
+				} )
+				.then( newEditor => {
+					expect( newEditor.sourceElement ).to.be.undefined;
+
+					return newEditor.destroy();
+				} );
 		} );
 
-		it( 'editor.element should contain created div element (the whole editor with UI)', () => {
+		it( 'editor.element should contain the whole editor (with UI) element', () => {
 			return BalloonEditor.create( '<p>Hello world!</p>', {
 				plugins: [ Paragraph ]
 			} ).then( editor => {
@@ -303,6 +306,14 @@ describe( 'BalloonEditor', () => {
 					expect( editorElement.innerHTML )
 						.to.equal( '<p>a</p><heading>b</heading>' );
 				} );
+		} );
+
+		it( 'should not throw an error if editor was initialized with the data', () => {
+			return BalloonEditor
+				.create( '<p>Foo.</p>', {
+					plugins: [ Paragraph, Bold ]
+				} )
+				.then( newEditor => newEditor.destroy() );
 		} );
 	} );
 } );

--- a/tests/ballooneditor.js
+++ b/tests/ballooneditor.js
@@ -111,12 +111,19 @@ describe( 'BalloonEditor', () => {
 			} );
 		} );
 
-		it( 'editor.element should contain created div element', () => {
+		it( 'editor.sourceElement should contain created div element', () => {
 			return BalloonEditor.create( '<p>Hello world!</p>', {
 				plugins: [ Paragraph ]
 			} ).then( editor => {
-				expect( editor.element ).to.be.instanceOf( HTMLElement );
-				expect( editor.element.tagName ).to.equal( 'DIV' );
+				expect( editor.sourceElement ).to.be.instanceOf( HTMLElement );
+				expect( editor.sourceElement.tagName ).to.equal( 'DIV' );
+			} );
+		} );
+
+		it( 'editor.element should contain created div element (the whole editor with UI)', () => {
+			return BalloonEditor.create( '<p>Hello world!</p>', {
+				plugins: [ Paragraph ]
+			} ).then( editor => {
 				expect( editor.editing.view.getDomRoot() ).to.equal( editor.element );
 			} );
 		} );
@@ -146,7 +153,10 @@ describe( 'BalloonEditor', () => {
 		} );
 
 		it( 'attaches editable UI as view\'s DOM root', () => {
-			expect( editor.editing.view.getDomRoot() ).to.equal( editor.ui.view.editable.element );
+			const domRoot = editor.editing.view.getDomRoot();
+
+			expect( domRoot ).to.equal( editor.element );
+			expect( domRoot ).to.equal( editor.ui.view.editable.element );
 		} );
 
 		it( 'creates the UI using BalloonEditorUI classes', () => {

--- a/tests/manual/ballooneditor-data.html
+++ b/tests/manual/ballooneditor-data.html
@@ -1,5 +1,5 @@
 <p>
-	<button id="destroyEditor">Destroy editor</button>
+	<button id="destroyEditors">Destroy editors</button>
 	<button id="initEditor">Init editor</button>
 </p>
 

--- a/tests/manual/ballooneditor-data.html
+++ b/tests/manual/ballooneditor-data.html
@@ -1,0 +1,11 @@
+<p>
+	<button id="destroyEditor">Destroy editor</button>
+	<button id="initEditor">Init editor</button>
+</p>
+
+<style>
+	body {
+		width: 10000px;
+		height: 10000px;
+	}
+</style>

--- a/tests/manual/ballooneditor-data.html
+++ b/tests/manual/ballooneditor-data.html
@@ -3,9 +3,17 @@
 	<button id="initEditor">Init editor</button>
 </p>
 
+<div class="container"></div>
+
 <style>
 	body {
 		width: 10000px;
 		height: 10000px;
+	}
+
+
+	.container {
+		padding: 20px;
+		width: 500px;
 	}
 </style>

--- a/tests/manual/ballooneditor-data.js
+++ b/tests/manual/ballooneditor-data.js
@@ -9,6 +9,7 @@ import BalloonEditor from '../../src/ballooneditor';
 import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
 
 window.editors = [];
+const container = document.querySelector( '.container' );
 
 function initEditor() {
 	BalloonEditor
@@ -18,7 +19,7 @@ function initEditor() {
 		} )
 		.then( editor => {
 			window.editors.push( editor );
-			document.body.appendChild( editor.element );
+			container.appendChild( editor.element );
 		} )
 		.catch( err => {
 			console.error( err.stack );

--- a/tests/manual/ballooneditor-data.js
+++ b/tests/manual/ballooneditor-data.js
@@ -1,0 +1,38 @@
+/**
+ * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* globals console:false, document, window */
+
+import BalloonEditor from '../../src/ballooneditor';
+import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
+
+window.editors = [];
+
+function initEditor() {
+	BalloonEditor
+		.create( '<h2>Editor 1</h2><p>This is an editor instance.</p>', {
+			plugins: [ ArticlePluginSet ],
+			toolbar: [ 'heading', '|', 'bold', 'italic', 'link', 'bulletedList', 'numberedList', 'blockQuote', 'undo', 'redo' ]
+		} )
+		.then( editor => {
+			window.editors.push( editor );
+			document.body.appendChild( editor.element );
+		} )
+		.catch( err => {
+			console.error( err.stack );
+		} );
+}
+
+function destroyEditor() {
+	window.editors.forEach( editor => {
+		editor.destroy()
+			.then( () => {
+				editor.element.remove();
+			} );
+	} );
+}
+
+document.getElementById( 'initEditor' ).addEventListener( 'click', initEditor );
+document.getElementById( 'destroyEditor' ).addEventListener( 'click', destroyEditor );

--- a/tests/manual/ballooneditor-data.js
+++ b/tests/manual/ballooneditor-data.js
@@ -10,14 +10,16 @@ import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articleplugi
 
 window.editors = [];
 const container = document.querySelector( '.container' );
+let counter = 1;
 
 function initEditor() {
 	BalloonEditor
-		.create( '<h2>Editor 1</h2><p>This is an editor instance.</p>', {
+		.create( `<h2>Editor ${ counter }</h2><p>This is an editor instance.</p>`, {
 			plugins: [ ArticlePluginSet ],
 			toolbar: [ 'heading', '|', 'bold', 'italic', 'link', 'bulletedList', 'numberedList', 'blockQuote', 'undo', 'redo' ]
 		} )
 		.then( editor => {
+			counter += 1;
 			window.editors.push( editor );
 			container.appendChild( editor.element );
 		} )
@@ -26,14 +28,16 @@ function initEditor() {
 		} );
 }
 
-function destroyEditor() {
+function destroyEditors() {
 	window.editors.forEach( editor => {
 		editor.destroy()
 			.then( () => {
 				editor.element.remove();
 			} );
 	} );
+	window.editors = [];
+	counter = 1;
 }
 
 document.getElementById( 'initEditor' ).addEventListener( 'click', initEditor );
-document.getElementById( 'destroyEditor' ).addEventListener( 'click', destroyEditor );
+document.getElementById( 'destroyEditors' ).addEventListener( 'click', destroyEditors );

--- a/tests/manual/ballooneditor-data.md
+++ b/tests/manual/ballooneditor-data.md
@@ -1,3 +1,3 @@
 1. Click "Init editor".
-2. New editor instance should be appended to the document with initial data in it.
-3. After clicking "Destroy editor" all editors should be removed from the document.
+2. New editor instance should be appended to the document with initial data in it. You can create more than one editor.
+3. After clicking "Destroy editors" all editors should be removed from the document.

--- a/tests/manual/ballooneditor-data.md
+++ b/tests/manual/ballooneditor-data.md
@@ -1,0 +1,3 @@
+1. Click "Init editor".
+2. New editor instance should be appended to the document with initial data in it.
+3. After clicking "Destroy editor" all editors should be removed from the document.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Editor can be created with initial data passed to the constructor. Closes ckeditor/ckeditor5#2342.

BREAKING CHANGE: `BalloonEditor#element` is now available as `BalloonEditor#sourceElement`. See ckeditor/ckeditor5#2882.

Requires: https://github.com/ckeditor/ckeditor5-core/pull/129