### PR TITLE
Moving calls to render child views in BallonEditorUIView out of the constructor

### DIFF
--- a/src/ballooneditoruiview.js
+++ b/src/ballooneditoruiview.js
@@ -40,7 +40,7 @@ export default class BalloonEditorUIView extends EditorUIView {
 	 */
 	render() {
 		super.render();
-		
+
 		this.registerChild( this.editable );
 	}
 

--- a/src/ballooneditoruiview.js
+++ b/src/ballooneditoruiview.js
@@ -33,7 +33,14 @@ export default class BalloonEditorUIView extends EditorUIView {
 		 * @member {module:ui/editableui/inline/inlineeditableuiview~InlineEditableUIView}
 		 */
 		this.editable = new InlineEditableUIView( locale, editableElement );
+	}
 
+	/**
+	 * @inheritDoc
+	 */
+	render() {
+		super.render();
+		
 		this.registerChild( this.editable );
 	}
 

--- a/tests/ballooneditoruiview.js
+++ b/tests/ballooneditoruiview.js
@@ -30,7 +30,7 @@ describe( 'BalloonEditorUIView', () => {
 			} );
 		} );
 	} );
-	
+
 	describe( 'render()', () => {
 		it( 'editable is registered as a child', () => {
 			const spy = sinon.spy( view.editable, 'destroy' );

--- a/tests/ballooneditoruiview.js
+++ b/tests/ballooneditoruiview.js
@@ -25,13 +25,19 @@ describe( 'BalloonEditorUIView', () => {
 				expect( view.editable.locale ).to.equal( locale );
 			} );
 
-			it( 'is registered as a child', () => {
-				const spy = sinon.spy( view.editable, 'destroy' );
-
-				view.render();
-				view.destroy();
-				sinon.assert.calledOnce( spy );
+			it( 'is not rendered', () => {
+				expect( view.editable.isRendered ).to.be.false;
 			} );
+		} );
+	} );
+	
+	describe( 'render()', () => {
+		it( 'editable is registered as a child', () => {
+			const spy = sinon.spy( view.editable, 'destroy' );
+
+			view.render();
+			view.destroy();
+			sinon.assert.calledOnce( spy );
 		} );
 	} );
 


### PR DESCRIPTION
Fix: Moving calls to render child views out of the constructor and in to the views own render function. 

---

### Additional information

- As per ckeditor/ckeditor5#1150
- Tests included.