### PR TITLE
Editor UI classes API refactoring

### DIFF
--- a/src/ballooneditor.js
+++ b/src/ballooneditor.js
@@ -191,8 +191,6 @@ export default class BalloonEditor extends Editor {
 				editor.initPlugins()
 					.then( () => {
 						editor.ui.init();
-						editor.ui.ready();
-						editor.fire( 'uiReady' );
 					} )
 					.then( () => {
 						const initialData = isElement( sourceElementOrData ) ?

--- a/src/ballooneditor.js
+++ b/src/ballooneditor.js
@@ -18,6 +18,7 @@ import DataApiMixin from '@ckeditor/ckeditor5-core/src/editor/utils/dataapimixin
 import ElementApiMixin from '@ckeditor/ckeditor5-core/src/editor/utils/elementapimixin';
 import attachToForm from '@ckeditor/ckeditor5-core/src/editor/utils/attachtoform';
 import mix from '@ckeditor/ckeditor5-utils/src/mix';
+import log from '@ckeditor/ckeditor5-utils/src/log';
 import { isElement } from 'lodash-es';
 
 /**
@@ -86,7 +87,8 @@ export default class BalloonEditor extends Editor {
 	 * @inheritDoc
 	 */
 	get element() {
-		return this.ui.view.editable.element;
+		log.warn( 'deprecated-editor-element: The editor#element is deprecated.' );
+		return this.ui.element;
 	}
 
 	/**
@@ -189,6 +191,7 @@ export default class BalloonEditor extends Editor {
 				editor.initPlugins()
 					.then( () => {
 						editor.ui.init();
+						editor.ui.ready();
 						editor.fire( 'uiReady' );
 					} )
 					.then( () => {

--- a/src/ballooneditor.js
+++ b/src/ballooneditor.js
@@ -18,7 +18,6 @@ import DataApiMixin from '@ckeditor/ckeditor5-core/src/editor/utils/dataapimixin
 import ElementApiMixin from '@ckeditor/ckeditor5-core/src/editor/utils/elementapimixin';
 import attachToForm from '@ckeditor/ckeditor5-core/src/editor/utils/attachtoform';
 import mix from '@ckeditor/ckeditor5-utils/src/mix';
-import log from '@ckeditor/ckeditor5-utils/src/log';
 import { isElement } from 'lodash-es';
 
 /**
@@ -81,14 +80,6 @@ export default class BalloonEditor extends Editor {
 		this.ui = new BalloonEditorUI( this, new BalloonEditorUIView( this.locale, this.sourceElement ) );
 
 		attachToForm( this );
-	}
-
-	/**
-	 * @inheritDoc
-	 */
-	get element() {
-		log.warn( 'deprecated-editor-element: The editor#element is deprecated.' );
-		return this.ui.element;
 	}
 
 	/**

--- a/src/ballooneditorui.js
+++ b/src/ballooneditorui.js
@@ -90,4 +90,13 @@ export default class BalloonEditorUI extends EditorUI {
 
 		this.fire( 'ready' );
 	}
+
+	/**
+	 * @inheritDoc
+	 */
+	destroy() {
+		this._view.destroy();
+
+		super.destroy();
+	}
 }

--- a/src/ballooneditorui.js
+++ b/src/ballooneditorui.js
@@ -92,5 +92,7 @@ export default class BalloonEditorUI extends EditorUI {
 				balloonToolbar.hide();
 			}
 		} );
+
+		this.ready();
 	}
 }

--- a/src/ballooneditorui.js
+++ b/src/ballooneditorui.js
@@ -40,10 +40,10 @@ export default class BalloonEditorUI extends EditorUI {
 		// Bind to focusTracker instead of editor.editing.view because otherwise
 		// focused editable styles disappear when view#toolbar is focused.
 		view.editable.bind( 'isFocused' ).to( this.focusTracker );
-		editor.editing.view.attachDomRoot( view.editableElement );
+		editor.editing.view.attachDomRoot( view.editable.editableElement );
 		view.editable.name = editingRoot.rootName;
 
-		this.focusTracker.add( view.editableElement );
+		this.focusTracker.add( view.editable.editableElement );
 
 		enableToolbarKeyboardFocus( {
 			origin: editor.editing.view,

--- a/src/ballooneditorui.js
+++ b/src/ballooneditorui.js
@@ -88,6 +88,6 @@ export default class BalloonEditorUI extends EditorUI {
 			}
 		} );
 
-		this.ready();
+		this.fire( 'ready' );
 	}
 }

--- a/src/ballooneditorui.js
+++ b/src/ballooneditorui.js
@@ -17,10 +17,45 @@ import enableToolbarKeyboardFocus from '@ckeditor/ckeditor5-ui/src/toolbar/enabl
  */
 export default class BalloonEditorUI extends EditorUI {
 	/**
+	 * Creates an instance of the balloon editor UI class.
+	 *
+	 * @param {module:core/editor/editor~Editor} editor The editor instance.
+	 * @param {module:ui/editorui/editoruiview~EditorUIView} view The view of the UI.
+	 */
+	constructor( editor, view ) {
+		super( editor );
+
+		/**
+		 * The main (top–most) view of the editor UI.
+		 *
+		 * @private
+		 * @member {module:ui/editorui/editoruiview~EditorUIView} #_view
+		 */
+		this._view = view;
+	}
+
+	/**
+	 * The main (top–most) view of the editor UI.
+	 *
+	 * @readonly
+	 * @member {module:ui/editorui/editoruiview~EditorUIView} #view
+	 */
+	get view() {
+		return this._view;
+	}
+
+	/**
 	 * @inheritDoc
 	 */
 	get element() {
 		return this.view.editable.element;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	getEditableElement( rootName = 'main' ) {
+		return this.view.editable.name === rootName ? this.view.editable : null;
 	}
 
 	/**

--- a/src/ballooneditorui.js
+++ b/src/ballooneditorui.js
@@ -55,7 +55,7 @@ export default class BalloonEditorUI extends EditorUI {
 	 * @inheritDoc
 	 */
 	getEditableElement( rootName = 'main' ) {
-		return this.view.editable.name === rootName ? this.view.editable : null;
+		return this.view.editable.name === rootName ? this.view.editable.element : null;
 	}
 
 	/**

--- a/src/ballooneditorui.js
+++ b/src/ballooneditorui.js
@@ -17,6 +17,13 @@ import enableToolbarKeyboardFocus from '@ckeditor/ckeditor5-ui/src/toolbar/enabl
  */
 export default class BalloonEditorUI extends EditorUI {
 	/**
+	 * @inheritDoc
+	 */
+	get element() {
+		return this.view.editable.element;
+	}
+
+	/**
 	 * Initializes the UI.
 	 */
 	init() {

--- a/src/ballooneditorui.js
+++ b/src/ballooneditorui.js
@@ -68,12 +68,12 @@ export default class BalloonEditorUI extends EditorUI {
 		// Bind to focusTracker instead of editor.editing.view because otherwise
 		// focused editable styles disappear when view#toolbar is focused.
 		view.editable.bind( 'isFocused' ).to( this.focusTracker );
-		editor.editing.view.attachDomRoot( view.editable.editableElement );
+		editor.editing.view.attachDomRoot( view.editable.element );
 		view.editable.name = editingRoot.rootName;
 
-		this._editableElements.push( view.editable );
+		this._editableElements.set( view.editable.name, view.editable.element );
 
-		this.focusTracker.add( view.editable.editableElement );
+		this.focusTracker.add( view.editable.element );
 
 		enableToolbarKeyboardFocus( {
 			origin: editor.editing.view,

--- a/src/ballooneditorui.js
+++ b/src/ballooneditorui.js
@@ -52,13 +52,6 @@ export default class BalloonEditorUI extends EditorUI {
 	}
 
 	/**
-	 * @inheritDoc
-	 */
-	getEditableElement( rootName = 'main' ) {
-		return this.view.editable.name === rootName ? this.view.editable.element : null;
-	}
-
-	/**
 	 * Initializes the UI.
 	 */
 	init() {
@@ -77,6 +70,8 @@ export default class BalloonEditorUI extends EditorUI {
 		view.editable.bind( 'isFocused' ).to( this.focusTracker );
 		editor.editing.view.attachDomRoot( view.editable.editableElement );
 		view.editable.name = editingRoot.rootName;
+
+		this._editableElements.push( view.editable );
 
 		this.focusTracker.add( view.editable.editableElement );
 

--- a/src/ballooneditoruiview.js
+++ b/src/ballooneditoruiview.js
@@ -9,7 +9,6 @@
 
 import EditorUIView from '@ckeditor/ckeditor5-ui/src/editorui/editoruiview';
 import InlineEditableUIView from '@ckeditor/ckeditor5-ui/src/editableui/inline/inlineeditableuiview';
-import log from '@ckeditor/ckeditor5-utils/src/log';
 
 /**
  * Contextual editor UI view. Uses the {@link module:ui/editableui/inline/inlineeditableuiview~InlineEditableUIView}.
@@ -43,21 +42,5 @@ export default class BalloonEditorUIView extends EditorUIView {
 		super.render();
 
 		this.registerChild( this.editable );
-	}
-
-	/**
-	 * **Deprecated** since `v12.0.0`. The {@link module:ui/editableui/editableuiview~EditableUIView#editableElement
-	 * `EditableUIView editableElement`} could be used instead.
-	 *
-	 * The element which is the main editable element (usually the one with `contentEditable="true"`).
-	 *
-	 * @deprecated v12.0.0 The {@link module:ui/editableui/editableuiview~EditableUIView#editableElement
-	 * `EditableUIView editableElement`} could be used instead.
-	 * @readonly
-	 * @member {HTMLElement} #editableElement
-	 */
-	get editableElement() {
-		log.warn( 'deprecated-ui-view-editableElement: The BalloonEditorUIView#editableElement property is deprecated.' );
-		return this.editable.editableElement;
 	}
 }

--- a/src/ballooneditoruiview.js
+++ b/src/ballooneditoruiview.js
@@ -9,6 +9,7 @@
 
 import EditorUIView from '@ckeditor/ckeditor5-ui/src/editorui/editoruiview';
 import InlineEditableUIView from '@ckeditor/ckeditor5-ui/src/editableui/inline/inlineeditableuiview';
+import log from '@ckeditor/ckeditor5-utils/src/log';
 
 /**
  * Contextual editor UI view. Uses the {@link module:ui/editableui/inline/inlineeditableuiview~InlineEditableUIView}.
@@ -45,9 +46,18 @@ export default class BalloonEditorUIView extends EditorUIView {
 	}
 
 	/**
-	 * @inheritDoc
+	 * **Deprecated** since `v12.0.0`. The {@link module:ui/editableui/editableuiview~EditableUIView#editableElement
+	 * `EditableUIView editableElement`} could be used instead.
+	 *
+	 * The element which is the main editable element (usually the one with `contentEditable="true"`).
+	 *
+	 * @deprecated v12.0.0 The {@link module:ui/editableui/editableuiview~EditableUIView#editableElement
+	 * `EditableUIView editableElement`} could be used instead.
+	 * @readonly
+	 * @member {HTMLElement} #editableElement
 	 */
 	get editableElement() {
-		return this.editable.element;
+		log.warn( 'deprecated-ui-view-editableElement: The BalloonEditorUIView#editableElement property is deprecated.' );
+		return this.editable.editableElement;
 	}
 }

--- a/tests/ballooneditor.js
+++ b/tests/ballooneditor.js
@@ -122,14 +122,6 @@ describe( 'BalloonEditor', () => {
 					return newEditor.destroy();
 				} );
 		} );
-
-		it( 'editor.element should contain the whole editor (with UI) element', () => {
-			return BalloonEditor.create( '<p>Hello world!</p>', {
-				plugins: [ Paragraph ]
-			} ).then( editor => {
-				expect( editor.editing.view.getDomRoot() ).to.equal( editor.element );
-			} );
-		} );
 	} );
 
 	describe( 'create()', () => {
@@ -158,7 +150,6 @@ describe( 'BalloonEditor', () => {
 		it( 'attaches editable UI as view\'s DOM root', () => {
 			const domRoot = editor.editing.view.getDomRoot();
 
-			expect( domRoot ).to.equal( editor.element );
 			expect( domRoot ).to.equal( editor.ui.view.editable.element );
 		} );
 
@@ -215,7 +206,6 @@ describe( 'BalloonEditor', () => {
 				init() {
 					this.editor.on( 'pluginsReady', spy );
 					this.editor.ui.on( 'ready', spy );
-					this.editor.on( 'uiReady', spy );
 					this.editor.on( 'dataReady', spy );
 					this.editor.on( 'ready', spy );
 				}
@@ -226,7 +216,7 @@ describe( 'BalloonEditor', () => {
 					plugins: [ EventWatcher ]
 				} )
 				.then( newEditor => {
-					expect( fired ).to.deep.equal( [ 'pluginsReady', 'ready', 'uiReady', 'dataReady', 'ready' ] );
+					expect( fired ).to.deep.equal( [ 'pluginsReady', 'ready', 'dataReady', 'ready' ] );
 
 					editor = newEditor;
 				} );
@@ -249,28 +239,6 @@ describe( 'BalloonEditor', () => {
 				} )
 				.then( newEditor => {
 					expect( data ).to.equal( '<p><strong>foo</strong> bar</p>' );
-
-					editor = newEditor;
-				} );
-		} );
-
-		it( 'fires uiReady once UI is ready', () => {
-			let isRendered;
-
-			class EventWatcher extends Plugin {
-				init() {
-					this.editor.on( 'uiReady', () => {
-						isRendered = this.editor.ui.view.isRendered;
-					} );
-				}
-			}
-
-			return BalloonEditor
-				.create( editorElement, {
-					plugins: [ EventWatcher ]
-				} )
-				.then( newEditor => {
-					expect( isRendered ).to.be.true;
 
 					editor = newEditor;
 				} );

--- a/tests/ballooneditor.js
+++ b/tests/ballooneditor.js
@@ -20,6 +20,7 @@ import ElementApiMixin from '@ckeditor/ckeditor5-core/src/editor/utils/elementap
 import RootElement from '@ckeditor/ckeditor5-engine/src/model/rootelement';
 
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
+import log from '@ckeditor/ckeditor5-utils/src/log';
 
 describe( 'BalloonEditor', () => {
 	let editor, editorElement;
@@ -31,6 +32,8 @@ describe( 'BalloonEditor', () => {
 		editorElement.innerHTML = '<p><strong>foo</strong> bar</p>';
 
 		document.body.appendChild( editorElement );
+
+		testUtils.sinon.stub( log, 'warn' ).callsFake( () => {} );
 	} );
 
 	afterEach( () => {
@@ -211,6 +214,7 @@ describe( 'BalloonEditor', () => {
 			class EventWatcher extends Plugin {
 				init() {
 					this.editor.on( 'pluginsReady', spy );
+					this.editor.ui.on( 'ready', spy );
 					this.editor.on( 'uiReady', spy );
 					this.editor.on( 'dataReady', spy );
 					this.editor.on( 'ready', spy );
@@ -222,7 +226,7 @@ describe( 'BalloonEditor', () => {
 					plugins: [ EventWatcher ]
 				} )
 				.then( newEditor => {
-					expect( fired ).to.deep.equal( [ 'pluginsReady', 'uiReady', 'dataReady', 'ready' ] );
+					expect( fired ).to.deep.equal( [ 'pluginsReady', 'ready', 'uiReady', 'dataReady', 'ready' ] );
 
 					editor = newEditor;
 				} );
@@ -256,6 +260,28 @@ describe( 'BalloonEditor', () => {
 			class EventWatcher extends Plugin {
 				init() {
 					this.editor.on( 'uiReady', () => {
+						isRendered = this.editor.ui.view.isRendered;
+					} );
+				}
+			}
+
+			return BalloonEditor
+				.create( editorElement, {
+					plugins: [ EventWatcher ]
+				} )
+				.then( newEditor => {
+					expect( isRendered ).to.be.true;
+
+					editor = newEditor;
+				} );
+		} );
+
+		it( 'fires ready once UI is ready', () => {
+			let isRendered;
+
+			class EventWatcher extends Plugin {
+				init() {
+					this.editor.ui.on( 'ready', () => {
 						isRendered = this.editor.ui.view.isRendered;
 					} );
 				}

--- a/tests/ballooneditorui.js
+++ b/tests/ballooneditorui.js
@@ -126,11 +126,11 @@ describe( 'BalloonEditorUI', () => {
 
 	describe( 'getEditableElement()', () => {
 		it( 'returns editable element (default)', () => {
-			expect( ui.getEditableElement() ).to.equal( view.editable );
+			expect( ui.getEditableElement() ).to.equal( view.editable.element );
 		} );
 
 		it( 'returns editable element (root name passed)', () => {
-			expect( ui.getEditableElement( 'main' ) ).to.equal( view.editable );
+			expect( ui.getEditableElement( 'main' ) ).to.equal( view.editable.element );
 		} );
 
 		it( 'returns null if editable with the given name is absent', () => {

--- a/tests/ballooneditorui.js
+++ b/tests/ballooneditorui.js
@@ -16,7 +16,7 @@ import utils from '@ckeditor/ckeditor5-utils/tests/_utils/utils';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 
 describe( 'BalloonEditorUI', () => {
-	let editor, view, ui;
+	let editor, view, ui, viewElement;
 
 	testUtils.createSinonSandbox();
 
@@ -29,6 +29,7 @@ describe( 'BalloonEditorUI', () => {
 				editor = newEditor;
 				ui = editor.ui;
 				view = ui.view;
+				viewElement = view.editable.element;
 			} );
 	} );
 
@@ -121,6 +122,12 @@ describe( 'BalloonEditorUI', () => {
 					{ isReadOnly: true }
 				);
 			} );
+		} );
+	} );
+
+	describe( 'element()', () => {
+		it( 'returns correct element instance', () => {
+			expect( ui.element ).to.equal( viewElement );
 		} );
 	} );
 

--- a/tests/ballooneditorui.js
+++ b/tests/ballooneditorui.js
@@ -123,6 +123,20 @@ describe( 'BalloonEditorUI', () => {
 			} );
 		} );
 	} );
+
+	describe( 'getEditableElement()', () => {
+		it( 'returns editable element (default)', () => {
+			expect( ui.getEditableElement() ).to.equal( view.editable );
+		} );
+
+		it( 'returns editable element (root name passed)', () => {
+			expect( ui.getEditableElement( 'main' ) ).to.equal( view.editable );
+		} );
+
+		it( 'returns null if editable with the given name is absent', () => {
+			expect( ui.getEditableElement( 'absent' ) ).to.null;
+		} );
+	} );
 } );
 
 class VirtualBalloonTestEditor extends VirtualTestEditor {

--- a/tests/ballooneditorui.js
+++ b/tests/ballooneditorui.js
@@ -147,6 +147,7 @@ class VirtualBalloonTestEditor extends VirtualTestEditor {
 				editor.initPlugins()
 					.then( () => {
 						editor.ui.init();
+						editor.ui.ready();
 						editor.fire( 'uiReady' );
 						editor.fire( 'dataReady' );
 						editor.fire( 'ready' );

--- a/tests/ballooneditorui.js
+++ b/tests/ballooneditorui.js
@@ -140,8 +140,8 @@ describe( 'BalloonEditorUI', () => {
 			expect( ui.getEditableElement( 'main' ) ).to.equal( view.editable.element );
 		} );
 
-		it( 'returns null if editable with the given name is absent', () => {
-			expect( ui.getEditableElement( 'absent' ) ).to.null;
+		it( 'returns undefined if editable with the given name is absent', () => {
+			expect( ui.getEditableElement( 'absent' ) ).to.be.undefined;
 		} );
 	} );
 } );

--- a/tests/ballooneditorui.js
+++ b/tests/ballooneditorui.js
@@ -161,8 +161,6 @@ class VirtualBalloonTestEditor extends VirtualTestEditor {
 				editor.initPlugins()
 					.then( () => {
 						editor.ui.init();
-						editor.ui.ready();
-						editor.fire( 'uiReady' );
 						editor.fire( 'dataReady' );
 						editor.fire( 'ready' );
 					} )

--- a/tests/ballooneditoruiview.js
+++ b/tests/ballooneditoruiview.js
@@ -8,7 +8,6 @@ import InlineEditableUIView from '@ckeditor/ckeditor5-ui/src/editableui/inline/i
 import Locale from '@ckeditor/ckeditor5-utils/src/locale';
 
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
-import log from '@ckeditor/ckeditor5-utils/src/log';
 
 describe( 'BalloonEditorUIView', () => {
 	let locale, view;
@@ -43,16 +42,6 @@ describe( 'BalloonEditorUIView', () => {
 			view.render();
 			view.destroy();
 			sinon.assert.calledOnce( spy );
-		} );
-	} );
-
-	describe( 'editableElement', () => {
-		it( 'returns editable\'s view element', () => {
-			testUtils.sinon.stub( log, 'warn' ).callsFake( () => {} );
-
-			view.render();
-			expect( view.editableElement.getAttribute( 'contentEditable' ) ).to.equal( 'true' );
-			view.destroy();
 		} );
 	} );
 } );

--- a/tests/ballooneditoruiview.js
+++ b/tests/ballooneditoruiview.js
@@ -7,8 +7,13 @@ import BalloonEditorUIView from '../src/ballooneditoruiview';
 import InlineEditableUIView from '@ckeditor/ckeditor5-ui/src/editableui/inline/inlineeditableuiview';
 import Locale from '@ckeditor/ckeditor5-utils/src/locale';
 
+import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
+import log from '@ckeditor/ckeditor5-utils/src/log';
+
 describe( 'BalloonEditorUIView', () => {
 	let locale, view;
+
+	testUtils.createSinonSandbox();
 
 	beforeEach( () => {
 		locale = new Locale( 'en' );
@@ -43,6 +48,8 @@ describe( 'BalloonEditorUIView', () => {
 
 	describe( 'editableElement', () => {
 		it( 'returns editable\'s view element', () => {
+			testUtils.sinon.stub( log, 'warn' ).callsFake( () => {} );
+
 			view.render();
 			expect( view.editableElement.getAttribute( 'contentEditable' ) ).to.equal( 'true' );
 			view.destroy();


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Editor UI classes API refactoring.

BREAKING CHANGE: Removed `BalloonEditor#element` property. The `BalloonEditorUI#element` property should be used instead.
BREAKING CHANGE: Removed `BalloonEditorUIView#editableElement`. Instead `BalloonEditorUI#getEditableElement()` method should be used.

---

### Additional information

See ckeditor/ckeditor5#1449 and https://github.com/ckeditor/ckeditor5/issues/1449#issuecomment-453479320 describing changes in each commit.

The CI should turn green after https://github.com/ckeditor/ckeditor5-core/pull/154 is merged.