### PR TITLE
t/ckeditor5/1517: The editor placeholder configuration using the `placeholder` attribute should be restricted to `<textarea>` only

### DIFF
--- a/src/ballooneditorui.js
+++ b/src/ballooneditorui.js
@@ -124,9 +124,10 @@ export default class BalloonEditorUI extends EditorUI {
 		const editor = this.editor;
 		const editingView = editor.editing.view;
 		const editingRoot = editingView.document.getRoot();
+		const sourceElement = editor.sourceElement;
 
 		const placeholderText = editor.config.get( 'placeholder' ) ||
-			editor.sourceElement && editor.sourceElement.dataset.placeholder;
+			sourceElement && sourceElement.tagName.toLowerCase() === 'textarea' && sourceElement.getAttribute( 'placeholder' );
 
 		if ( placeholderText ) {
 			enablePlaceholder( {

--- a/src/ballooneditorui.js
+++ b/src/ballooneditorui.js
@@ -126,7 +126,7 @@ export default class BalloonEditorUI extends EditorUI {
 		const editingRoot = editingView.document.getRoot();
 
 		const placeholderText = editor.config.get( 'placeholder' ) ||
-			editor.sourceElement && editor.sourceElement.getAttribute( 'placeholder' );
+			editor.sourceElement && editor.sourceElement.dataset.placeholder;
 
 		if ( placeholderText ) {
 			enablePlaceholder( {

--- a/tests/ballooneditorui.js
+++ b/tests/ballooneditorui.js
@@ -131,10 +131,10 @@ describe( 'BalloonEditorUI', () => {
 					} );
 			} );
 
-			it( 'sets placeholder from "placeholder" attribute of a passed element', () => {
+			it( 'sets placeholder from the "data-placeholder" attribute of a passed element', () => {
 				const element = document.createElement( 'div' );
 
-				element.setAttribute( 'placeholder', 'placeholder-text' );
+				element.dataset.placeholder = 'placeholder-text';
 
 				return VirtualBalloonTestEditor
 					.create( element, {
@@ -149,10 +149,10 @@ describe( 'BalloonEditorUI', () => {
 					} );
 			} );
 
-			it( 'uses editor.config.placeholder rather than "placeholder" attribute of a passed element', () => {
+			it( 'uses editor.config.placeholder rather than the "data-placeholder" attribute of a passed element', () => {
 				const element = document.createElement( 'div' );
 
-				element.setAttribute( 'placeholder', 'placeholder-text' );
+				element.dataset.placeholder = 'placeholder-text';
 
 				return VirtualBalloonTestEditor
 					.create( element, {

--- a/tests/ballooneditorui.js
+++ b/tests/ballooneditorui.js
@@ -131,14 +131,15 @@ describe( 'BalloonEditorUI', () => {
 					} );
 			} );
 
-			it( 'sets placeholder from the "data-placeholder" attribute of a passed element', () => {
-				const element = document.createElement( 'div' );
+			it( 'sets placeholder from the "placeholder" attribute of a passed <textarea>', () => {
+				const element = document.createElement( 'textarea' );
 
-				element.dataset.placeholder = 'placeholder-text';
+				element.setAttribute( 'placeholder', 'placeholder-text' );
 
 				return VirtualBalloonTestEditor
 					.create( element, {
-						extraPlugins: [ BalloonToolbar, Paragraph ]
+						plugins: [ BalloonToolbar ],
+						extraPlugins: [ Paragraph ]
 					} )
 					.then( newEditor => {
 						const firstChild = newEditor.editing.view.document.getRoot().getChild( 0 );
@@ -149,15 +150,16 @@ describe( 'BalloonEditorUI', () => {
 					} );
 			} );
 
-			it( 'uses editor.config.placeholder rather than the "data-placeholder" attribute of a passed element', () => {
-				const element = document.createElement( 'div' );
+			it( 'uses editor.config.placeholder rather than the "placeholder" attribute of a passed <textarea>', () => {
+				const element = document.createElement( 'textarea' );
 
-				element.dataset.placeholder = 'placeholder-text';
+				element.setAttribute( 'placeholder', 'placeholder-text' );
 
 				return VirtualBalloonTestEditor
 					.create( element, {
+						plugins: [ BalloonToolbar ],
+						extraPlugins: [ Paragraph ],
 						placeholder: 'config takes precedence',
-						extraPlugins: [ BalloonToolbar, Paragraph ]
 					} )
 					.then( newEditor => {
 						const firstChild = newEditor.editing.view.document.getRoot().getChild( 0 );

--- a/tests/manual/placeholder.html
+++ b/tests/manual/placeholder.html
@@ -1,5 +1,5 @@
-<div id="editor-1" placeholder="Placeholder from the attribute">
+<div id="editor-1" data-placeholder="Placeholder from the attribute">
 	<p>Remove this text to see the placeholder.</p>
 </div>
 <br />
-<div id="editor-2" placeholder="Placeholder from the attribute"></div>
+<div id="editor-2" data-placeholder="Placeholder from the attribute"></div>

--- a/tests/manual/placeholder.html
+++ b/tests/manual/placeholder.html
@@ -1,5 +1,5 @@
-<div id="editor-1" data-placeholder="Placeholder from the attribute">
+<textarea id="editor-1" placeholder="Placeholder from the attribute">
 	<p>Remove this text to see the placeholder.</p>
-</div>
+</textarea>
 <br />
 <div id="editor-2" data-placeholder="Placeholder from the attribute"></div>


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: The editor placeholder configuration using the `placeholder` attribute should be restricted to `<textarea>` only (see ckeditor/ckeditor5#1517).

---

### Additional information

Part of https://github.com/ckeditor/ckeditor5/pull/1518.
