### PR TITLE
Introduced EditorConfig#initialData. Made config param optional

### DIFF
--- a/src/ballooneditor.js
+++ b/src/ballooneditor.js
@@ -122,7 +122,7 @@ export default class BalloonEditor extends Editor {
 	 *				console.error( err.stack );
 	 *			} );
 	 *
-	 * The element's content will be used as the editor data.
+	 * The element's content will be used as the editor data and it will become the editable element.
 	 *
 	 * Alternatively, you can initialize the editor by passing the initial data directly as a `String`.
 	 * In this case, the editor will render an element that must be inserted into the DOM for the editor to work properly:

--- a/src/ballooneditor.js
+++ b/src/ballooneditor.js
@@ -122,7 +122,7 @@ export default class BalloonEditor extends Editor {
 	 *				console.error( err.stack );
 	 *			} );
 	 *
-	 * This is the most convenient and common way to initialize the editor. The element's content will be used as the editor data.
+	 * The element's content will be used as the editor data.
 	 *
 	 * Alternatively, you can initialize the editor by passing the initial data directly as a `String`.
 	 * In this case, the editor will render an element that must be inserted into the DOM for the editor to work properly:
@@ -167,13 +167,8 @@ export default class BalloonEditor extends Editor {
 	 * or the editor's initial data.
 	 *
 	 * If a DOM element is passed, its content will be automatically
-	 * {@link module:editor-balloon/ballooneditor~BalloonEditor#setData loaded} to the editor upon initialization
-	 * and the {@link module:core/editor/editorui~EditorUI#getEditableElement editor element} will replace the passed element in the DOM
-	 * (the original one will be hidden and the editor will be injected next to it).
-	 *
-	 * Moreover, the editor data will be set back to the original element once the editor is destroyed and when a form, in which
-	 * this element is contained, is submitted (if the original element is a `<textarea>`). This ensures seamless integration with native
-	 * web forms.
+	 * {@link module:editor-balloon/ballooneditor~BalloonEditor#initData loaded} to the editor upon initialization.
+	 * Moreover, the editor data will be set back to the original element once the editor is destroyed.
 	 *
 	 * If the initial data is passed, a detached editor will be created. In this case you need to insert it into the DOM manually.
 	 * It is available under {@link module:editor-classic/classiceditorui~BalloonEditorUI#element `editor.ui.element`} property.

--- a/src/ballooneditor.js
+++ b/src/ballooneditor.js
@@ -122,7 +122,7 @@ export default class BalloonEditor extends Editor {
 	 *				console.error( err.stack );
 	 *			} );
 	 *
-	 * The element's content will be used as the editor data and it will become the editable element.
+	 * The element's content will be used as the editor data and the element will become the editable element.
 	 *
 	 * Alternatively, you can initialize the editor by passing the initial data directly as a `String`.
 	 * In this case, the editor will render an element that must be inserted into the DOM for the editor to work properly:

--- a/src/ballooneditor.js
+++ b/src/ballooneditor.js
@@ -107,9 +107,11 @@ export default class BalloonEditor extends Editor {
 	}
 
 	/**
-	 * Creates a balloon editor instance.
+	 * Creates a `BalloonEditor` instance.
 	 *
-	 * Creating an instance when using a {@glink builds/index CKEditor build}:
+	 * There are two general ways how the editor can be initialized.
+	 *
+	 * You can initialize the editor using an existing DOM element:
 	 *
 	 *		BalloonEditor
 	 *			.create( document.querySelector( '#editor' ) )
@@ -120,51 +122,27 @@ export default class BalloonEditor extends Editor {
 	 *				console.error( err.stack );
 	 *			} );
 	 *
-	 * Creating an instance when using CKEditor from source (make sure to specify the list of plugins to load and the toolbar):
+	 * This is the most convenient and common way to initialize the editor. The element's content will be used as the editor data.
 	 *
-	 *		import BalloonEditor from '@ckeditor/ckeditor5-editor-balloon/src/ballooneditor';
-	 *		import Essentials from '@ckeditor/ckeditor5-essentials/src/essentials';
-	 *		import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
-	 *		import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic';
-	 *		import ...
+	 * Alternatively, you can initialize the editor by passing the initial data directly as a `String`.
+	 * In this case, the editor will render an element that must be inserted into the DOM for the editor to work properly:
 	 *
 	 *		BalloonEditor
-	 *			.create( document.querySelector( '#editor' ), {
-	 *				plugins: [ Essentials, Bold, Italic, ... ],
-	 *				toolbar: [ 'bold', 'italic', ... ]
-	 *			} )
+	 *			.create( '<p>Hello world!</p>' )
 	 *			.then( editor => {
 	 *				console.log( 'Editor was initialized', editor );
+	 *
+	 *				// Initial data was provided so the editor UI element needs to be added manually to the DOM.
+	 *				document.body.appendChild( editor.ui.element );
 	 *			} )
 	 *			.catch( err => {
 	 *				console.error( err.stack );
 	 *			} );
 	 *
-	 * Creating an instance when using initial data instead of a DOM element.
-	 * The editor will then render an editable element that must be inserted into the DOM for the editor to work properly:
+	 * This lets you dynamically append the editor to your web page whenever it is convenient for you. You may use this method if your
+	 * web page content is generated on the client-side and the DOM structure is not ready at the moment when you initialize the editor.
 	 *
-	 *		import BalloonEditor from '@ckeditor/ckeditor5-editor-balloon/src/ballooneditor';
-	 *		import Essentials from '@ckeditor/ckeditor5-essentials/src/essentials';
-	 *		import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
-	 *		import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic';
-	 *		import ...
-	 *
-	 *		BalloonEditor
-	 *			.create( '<p>Hello world!</p>', {
-	 *				plugins: [ Essentials, Bold, Italic, ... ],
-	 *				toolbar: [ 'bold', 'italic', ... ]
-	 *			} )
-	 *			.then( editor => {
-	 *				console.log( 'Editor was initialized', editor );
-	 *
-	 *				// Initial data was provided so `editor.element` needs to be added manually to the DOM.
-	 *				document.body.appendChild( editor.element );
-	 *			} )
-	 *			.catch( err => {
-	 *				console.error( err.stack );
-	 *			} );
-	 *
-	 * Creating an instance on an existing DOM element using external initial content (specified in config):
+	 * You can also mix those two ways by providing a DOM element to be used and passing the initial data through the config:
 	 *
 	 *		BalloonEditor
 	 *			.create( document.querySelector( '#editor' ), {
@@ -177,18 +155,31 @@ export default class BalloonEditor extends Editor {
 	 *				console.error( err.stack );
 	 *			} );
 	 *
+	 * This method can be used to initialize the editor on an existing element with specified content in case if your integration
+	 * makes it difficult to set the content of the source element.
+	 *
+	 * Note that an error will be thrown if you pass initial data both as the first parameter and also in the config.
+	 *
+	 * See also the {@link module:core/editor/editorconfig~EditorConfig editor configuration documentation} to learn more about
+	 * customizing plugins, toolbar and other.
+	 *
 	 * @param {HTMLElement|String} sourceElementOrData The DOM element that will be the source for the created editor
-	 * (on which the editor will be initialized) or initial data for the editor.
+	 * or the editor's initial data.
 	 *
-	 * If a source element is passed, then its contents will be automatically
-	 * {@link module:editor-balloon/ballooneditor~BalloonEditor#setData loaded} to the editor on startup and the element
-	 * itself will be used as the editor's editable element.
+	 * If a DOM element is passed, its content will be automatically
+	 * {@link module:editor-balloon/ballooneditor~BalloonEditor#setData loaded} to the editor upon initialization
+	 * and the {@link module:core/editor/editorui~EditorUI#getEditableElement editor element} will replace the passed element in the DOM
+	 * (the original one will be hidden and the editor will be injected next to it).
 	 *
-	 * If data is provided, then `editor.element` will be created automatically and needs to be added
-	 * to the DOM manually.
+	 * Moreover, the editor data will be set back to the original element once the editor is destroyed and when a form, in which
+	 * this element is contained, is submitted (if the original element is a `<textarea>`). This ensures seamless integration with native
+	 * web forms.
+	 *
+	 * If the initial data is passed, a detached editor will be created. In this case you need to insert it into the DOM manually.
+	 * It is available under {@link module:editor-classic/classiceditorui~BalloonEditorUI#element `editor.ui.element`} property.
+	 *
 	 * @param {module:core/editor/editorconfig~EditorConfig} [config] The editor configuration.
-	 * @returns {Promise} A promise resolved once the editor is ready.
-	 * The promise returns the created {@link module:editor-balloon/ballooneditor~BalloonEditor} instance.
+	 * @returns {Promise} A promise resolved once the editor is ready. The promise resolves with the created editor instance.
 	 */
 	static create( sourceElementOrData, config = {} ) {
 		return new Promise( resolve => {

--- a/src/ballooneditor.js
+++ b/src/ballooneditor.js
@@ -166,12 +166,11 @@ export default class BalloonEditor extends Editor {
 	 * @param {HTMLElement|String} sourceElementOrData The DOM element that will be the source for the created editor
 	 * or the editor's initial data.
 	 *
-	 * If a DOM element is passed, its content will be automatically
-	 * {@link module:editor-balloon/ballooneditor~BalloonEditor#initData loaded} to the editor upon initialization.
+	 * If a DOM element is passed, its content will be automatically loaded to the editor upon initialization.
 	 * Moreover, the editor data will be set back to the original element once the editor is destroyed.
 	 *
 	 * If the initial data is passed, a detached editor will be created. In this case you need to insert it into the DOM manually.
-	 * It is available under {@link module:editor-classic/classiceditorui~BalloonEditorUI#element `editor.ui.element`} property.
+	 * It is available under {@link module:editor-balloon/ballooneditorui~BalloonEditorUI#element `editor.ui.element`} property.
 	 *
 	 * @param {module:core/editor/editorconfig~EditorConfig} [config] The editor configuration.
 	 * @returns {Promise} A promise resolved once the editor is ready. The promise resolves with the created editor instance.

--- a/tests/ballooneditor.js
+++ b/tests/ballooneditor.js
@@ -106,14 +106,6 @@ describe( 'BalloonEditor', () => {
 			} );
 		} );
 
-		it( 'allows to pass data to the constructor', () => {
-			return BalloonEditor.create( '<p>Hello world!</p>', {
-				plugins: [ Paragraph ]
-			} ).then( editor => {
-				expect( editor.getData() ).to.equal( '<p>Hello world!</p>' );
-			} );
-		} );
-
 		it( 'should have undefined the #sourceElement if editor was initialized with data', () => {
 			return BalloonEditor
 				.create( '<p>Foo.</p>', {
@@ -163,6 +155,49 @@ describe( 'BalloonEditor', () => {
 
 		it( 'loads data from the editor element', () => {
 			expect( editor.getData() ).to.equal( '<p><strong>foo</strong> bar</p>' );
+		} );
+
+		it( 'should not require config object', () => {
+			// Just being safe with `builtinPlugins` static property.
+			class CustomBalloonEditor extends BalloonEditor {}
+			CustomBalloonEditor.builtinPlugins = [ Paragraph, Bold ];
+
+			return CustomBalloonEditor.create( editorElement )
+				.then( newEditor => {
+					expect( newEditor.getData() ).to.equal( '<p><strong>foo</strong> bar</p>' );
+
+					return newEditor.destroy();
+				} );
+		} );
+
+		it( 'allows to pass data to the constructor', () => {
+			return BalloonEditor.create( '<p>Hello world!</p>', {
+				plugins: [ Paragraph ]
+			} ).then( editor => {
+				expect( editor.getData() ).to.equal( '<p>Hello world!</p>' );
+
+				editor.destroy();
+			} );
+		} );
+
+		it( 'initializes with config.initialData', () => {
+			return BalloonEditor.create( editorElement, {
+				initialData: '<p>Hello world!</p>',
+				plugins: [ Paragraph ]
+			} ).then( editor => {
+				expect( editor.getData() ).to.equal( '<p>Hello world!</p>' );
+
+				editor.destroy();
+			} );
+		} );
+
+		it( 'throws if initial data is passed in Editor#create and config.initialData is also used', done => {
+			BalloonEditor.create( '<p>Hello world!</p>', {
+				initialData: '<p>I am evil!</p>',
+				plugins: [ Paragraph ]
+			} ).catch( () => {
+				done();
+			} );
 		} );
 
 		// ckeditor/ckeditor5-editor-classic#53

--- a/tests/manual/ballooneditor-data.js
+++ b/tests/manual/ballooneditor-data.js
@@ -21,7 +21,7 @@ function initEditor() {
 		.then( editor => {
 			counter += 1;
 			window.editors.push( editor );
-			container.appendChild( editor.element );
+			container.appendChild( editor.ui.element );
 		} )
 		.catch( err => {
 			console.error( err.stack );
@@ -32,7 +32,7 @@ function destroyEditors() {
 	window.editors.forEach( editor => {
 		editor.destroy()
 			.then( () => {
-				editor.element.remove();
+				editor.ui.element.remove();
 			} );
 	} );
 	window.editors = [];


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Introduced `EditorConfig#initialData`.

---

### Additional information

Part of https://github.com/ckeditor/ckeditor5/issues/1619.

Also, I've made `config` parameter in `Editor.create()` optional. There is no need for it and we also have an example in docs without using it.