### PR TITLE
BalloonEditor.create() will throw an error, when textarea element is used.

### DIFF
--- a/src/ballooneditor.js
+++ b/src/ballooneditor.js
@@ -195,30 +195,31 @@ export default class BalloonEditor extends Editor {
 	 * @returns {Promise} A promise resolved once the editor is ready. The promise resolves with the created editor instance.
 	 */
 	static create( sourceElementOrData, config = {} ) {
-		let editor;
-		return Editor.allowedElement( sourceElementOrData )
-			.then( () => {
-				editor = new this( sourceElementOrData, config );
-			} )
-			.then( () => editor.initPlugins() )
-			.then( () => {
-				editor.ui.init();
-			} )
-			.then( () => {
-				if ( !isElement( sourceElementOrData ) && config.initialData ) {
-					// Documented in core/editor/editorconfig.jdoc.
-					throw new CKEditorError(
-						'editor-create-initial-data: ' +
-						'The config.initialData option cannot be used together with initial data passed in Editor.create().'
-					);
-				}
+		return new Promise( resolve => {
+			const editor = new this( sourceElementOrData, config );
 
-				const initialData = config.initialData || getInitialData( sourceElementOrData );
+			resolve(
+				editor.initPlugins()
+					.then( () => {
+						editor.ui.init();
+					} )
+					.then( () => {
+						if ( !isElement( sourceElementOrData ) && config.initialData ) {
+							// Documented in core/editor/editorconfig.jdoc.
+							throw new CKEditorError(
+								'editor-create-initial-data: ' +
+								'The config.initialData option cannot be used together with initial data passed in Editor.create().'
+							);
+						}
 
-				return editor.data.init( initialData );
-			} )
-			.then( () => editor.fire( 'ready' ) )
-			.then( () => editor );
+						const initialData = config.initialData || getInitialData( sourceElementOrData );
+
+						return editor.data.init( initialData );
+					} )
+					.then( () => editor.fire( 'ready' ) )
+					.then( () => editor )
+			);
+		} );
 	}
 }
 

--- a/src/ballooneditor.js
+++ b/src/ballooneditor.js
@@ -195,31 +195,30 @@ export default class BalloonEditor extends Editor {
 	 * @returns {Promise} A promise resolved once the editor is ready. The promise resolves with the created editor instance.
 	 */
 	static create( sourceElementOrData, config = {} ) {
-		return new Promise( resolve => {
-			const editor = new this( sourceElementOrData, config );
+		let editor;
+		return Editor.allowedElement( sourceElementOrData )
+			.then( () => {
+				editor = new this( sourceElementOrData, config );
+			} )
+			.then( () => editor.initPlugins() )
+			.then( () => {
+				editor.ui.init();
+			} )
+			.then( () => {
+				if ( !isElement( sourceElementOrData ) && config.initialData ) {
+					// Documented in core/editor/editorconfig.jdoc.
+					throw new CKEditorError(
+						'editor-create-initial-data: ' +
+						'The config.initialData option cannot be used together with initial data passed in Editor.create().'
+					);
+				}
 
-			resolve(
-				editor.initPlugins()
-					.then( () => {
-						editor.ui.init();
-					} )
-					.then( () => {
-						if ( !isElement( sourceElementOrData ) && config.initialData ) {
-							// Documented in core/editor/editorconfig.jdoc.
-							throw new CKEditorError(
-								'editor-create-initial-data: ' +
-								'The config.initialData option cannot be used together with initial data passed in Editor.create().'
-							);
-						}
+				const initialData = config.initialData || getInitialData( sourceElementOrData );
 
-						const initialData = config.initialData || getInitialData( sourceElementOrData );
-
-						return editor.data.init( initialData );
-					} )
-					.then( () => editor.fire( 'ready' ) )
-					.then( () => editor )
-			);
-		} );
+				return editor.data.init( initialData );
+			} )
+			.then( () => editor.fire( 'ready' ) )
+			.then( () => editor );
 	}
 }
 

--- a/src/ballooneditor.js
+++ b/src/ballooneditor.js
@@ -196,6 +196,8 @@ export default class BalloonEditor extends Editor {
 	 */
 	static create( sourceElementOrData, config = {} ) {
 		return new Promise( resolve => {
+			Editor._assertAllowedSourceElement( sourceElementOrData );
+
 			const editor = new this( sourceElementOrData, config );
 
 			resolve(

--- a/src/ballooneditor.js
+++ b/src/ballooneditor.js
@@ -196,7 +196,12 @@ export default class BalloonEditor extends Editor {
 	 */
 	static create( sourceElementOrData, config = {} ) {
 		return new Promise( resolve => {
-			Editor._assertAllowedSourceElement( sourceElementOrData );
+			const isHTMLElement = isElement( sourceElementOrData );
+
+			if ( isHTMLElement && sourceElementOrData.tagName === 'TEXTAREA' ) {
+				// Documented in core/editor/editor.js
+				throw new CKEditorError( 'editor-wrong-element: This type of editor cannot be initialized inside <textarea> element.' );
+			}
 
 			const editor = new this( sourceElementOrData, config );
 
@@ -206,7 +211,7 @@ export default class BalloonEditor extends Editor {
 						editor.ui.init();
 					} )
 					.then( () => {
-						if ( !isElement( sourceElementOrData ) && config.initialData ) {
+						if ( !isHTMLElement && config.initialData ) {
 							// Documented in core/editor/editorconfig.jdoc.
 							throw new CKEditorError(
 								'editor-create-initial-data: ' +

--- a/tests/ballooneditor.js
+++ b/tests/ballooneditor.js
@@ -164,9 +164,19 @@ describe( 'BalloonEditor', () => {
 			BalloonEditor.create( '<p>Hello world!</p>', {
 				initialData: '<p>I am evil!</p>',
 				plugins: [ Paragraph ]
-			} ).catch( () => {
-				done();
-			} );
+			} )
+				.then(
+					() => {
+						expect.fail( 'Balloon editor should throw an error when both initial data are passed' );
+					},
+					err => {
+						expect( err ).to.be.an( 'error' ).with.property( 'message' ).and
+							// eslint-disable-next-line max-len
+							.match( /^editor-create-initial-data: The config\.initialData option cannot be used together with initial data passed in Editor\.create\(\)\./ );
+					}
+				)
+				.then( done )
+				.catch( done );
 		} );
 
 		// ckeditor/ckeditor5-editor-classic#53

--- a/tests/ballooneditor.js
+++ b/tests/ballooneditor.js
@@ -195,6 +195,21 @@ describe( 'BalloonEditor', () => {
 					return newEditor.destroy();
 				} );
 		} );
+
+		it( 'throws an error when is initialized in textarea', done => {
+			BalloonEditor.create( document.createElement( 'textarea' ) )
+				.then(
+					() => {
+						expect.fail( 'Balloon editor should throw an error when is initialized in textarea.' );
+					},
+					err => {
+						expect( err ).to.be.an( 'error' ).with.property( 'message' ).and
+							.match( /^editor-wrong-element: This type of editor cannot be initialized inside <textarea> element\./ );
+					}
+				)
+				.then( done )
+				.catch( done );
+		} );
 	} );
 
 	describe( 'create - events', () => {

--- a/tests/ballooneditor.js
+++ b/tests/ballooneditor.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-/* globals document, Event */
+/* globals document */
 
 import BalloonEditorUI from '../src/ballooneditorui';
 import BalloonEditorUIView from '../src/ballooneditoruiview';
@@ -73,37 +73,6 @@ describe( 'BalloonEditor', () => {
 
 		it( 'creates main root element', () => {
 			expect( editor.model.document.getRoot( 'main' ) ).to.instanceof( RootElement );
-		} );
-
-		it( 'handles form element', () => {
-			const form = document.createElement( 'form' );
-			const textarea = document.createElement( 'textarea' );
-			form.appendChild( textarea );
-			document.body.appendChild( form );
-
-			// Prevents page realods in Firefox ;|
-			form.addEventListener( 'submit', evt => {
-				evt.preventDefault();
-			} );
-
-			return BalloonEditor.create( textarea, {
-				plugins: [ Paragraph ]
-			} ).then( editor => {
-				expect( textarea.value ).to.equal( '' );
-
-				editor.setData( '<p>Foo</p>' );
-
-				form.dispatchEvent( new Event( 'submit', {
-					// We need to be able to do preventDefault() to prevent page reloads in Firefox.
-					cancelable: true
-				} ) );
-
-				expect( textarea.value ).to.equal( '<p>Foo</p>' );
-
-				return editor.destroy().then( () => {
-					form.remove();
-				} );
-			} );
 		} );
 
 		it( 'should have undefined the #sourceElement if editor was initialized with data', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: `BalloonEditor.create()` will throw an error, when textarea element is used.

---

### Additional information

* PR requires: ckeditor/ckeditor5-core#173