### PR TITLE
t/ckeditor5/1838: Used the new `EditorUI#setEditableElement()` API in the `BalloonEditorUI` class

### DIFF
--- a/src/ballooneditorui.js
+++ b/src/ballooneditorui.js
@@ -65,7 +65,7 @@ export default class BalloonEditorUI extends EditorUI {
 
 		// Register the editable UI view in the editor. A single editor instance can aggregate multiple
 		// editable areas (roots) but the balloon editor has only one.
-		this._editableElements.set( editable.name, editableElement );
+		this.setEditableElement( editable.name, editableElement );
 
 		// Let the global focus tracker know that the editable UI element is focusable and
 		// belongs to the editor. From now on, the focus tracker will sustain the editor focus


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Used the new `EditorUI#setEditableElement()` API in the `BalloonEditorUI` class (see ckeditor/ckeditor5#1838).

---

A piece of ckeditor/ckeditor5#1840.